### PR TITLE
Fix authentication flow for existing Google users

### DIFF
--- a/app/src/main/java/com/example/reciplan/ui/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/example/reciplan/ui/auth/AuthViewModel.kt
@@ -31,22 +31,29 @@ class AuthViewModel(
             authRepository.getAuthState().collect { state ->
                 when (state) {
                     is com.example.reciplan.data.auth.AuthState.Authenticated -> {
-                        val user = authRepository.getCurrentUser()
-                        if (user != null) {
-                            _authState.value = AuthResult.Success(
-                                com.example.reciplan.data.model.User(
-                                    id = user.uid,
-                                    email = user.email ?: "",
-                                    name = user.displayName,
-                                    username = null,
-                                    photoUrl = user.photoUrl?.toString(),
-                                    emailVerified = user.isEmailVerified,
-                                    created_at = "",
-                                    updated_at = ""
-                                )
-                            )
+                        // Fetch the actual user data from backend
+                        val userData = authRepository.getCurrentUserData()
+                        if (userData != null) {
+                            _authState.value = AuthResult.Success(userData)
                         } else {
-                            _authState.value = AuthResult.Error("User not authenticated")
+                            // Fallback to Firebase user data if backend data is not available
+                            val firebaseUser = authRepository.getCurrentUser()
+                            if (firebaseUser != null) {
+                                _authState.value = AuthResult.Success(
+                                    com.example.reciplan.data.model.User(
+                                        id = firebaseUser.uid,
+                                        email = firebaseUser.email ?: "",
+                                        name = firebaseUser.displayName,
+                                        username = null,
+                                        photoUrl = firebaseUser.photoUrl?.toString(),
+                                        emailVerified = firebaseUser.isEmailVerified,
+                                        created_at = "",
+                                        updated_at = ""
+                                    )
+                                )
+                            } else {
+                                _authState.value = AuthResult.Error("User not authenticated")
+                            }
                         }
                     }
                     is com.example.reciplan.data.auth.AuthState.Unauthenticated -> {

--- a/app/src/main/java/com/example/reciplan/ui/auth/ChooseUsernameScreen.kt
+++ b/app/src/main/java/com/example/reciplan/ui/auth/ChooseUsernameScreen.kt
@@ -173,12 +173,33 @@ fun ChooseUsernameScreen(
                     containerColor = MaterialTheme.colorScheme.errorContainer
                 )
             ) {
-                Text(
-                    text = errorState.message,
-                    modifier = Modifier.padding(16.dp),
-                    color = MaterialTheme.colorScheme.onErrorContainer,
-                    style = MaterialTheme.typography.bodyMedium
-                )
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(
+                        text = errorState.message,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    
+                    // If the error indicates the user already has an account, provide an option to skip
+                    if (errorState.message.contains("already has an account", ignoreCase = true)) {
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            text = "It looks like you already have an account. You can skip this step and go directly to the app.",
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Button(
+                            onClick = { onUsernameSet() },
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.primary
+                            )
+                        ) {
+                            Text("Skip to App")
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
- Use setup_required flag from backend to determine if user setup is complete
- Fetch actual user data from backend instead of creating manual User objects
- Add better error handling for users who already have accounts
- Provide skip option for users who already have accounts but reach username screen

Fixes issue where existing users would get stuck on username screen after Google login